### PR TITLE
Explicitly delete port

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -60,9 +60,9 @@ module.exports = class Server extends Emitter {
 					nope(new Error(`${ErrorMessages.EADDRINUSE} - ${this.options.path}`));
 					return;
 				} catch(e) { /* no-op */ }
+				delete this.options.listener.port;
 				this.server.listen({
 					...this.options.listener,
-					port: void 0,
 					path: this.options.path
 				});
 			} else if(this.options.port) {


### PR DESCRIPTION
if listener options.port is set to undefined, node treats it as a 0 and binds to a tcp socket instead of a unix socket

fixes #2 