### PR TITLE
types: ping and survey return an array

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -73,8 +73,8 @@ declare module "net-ipc" {
 		start(): Promise<this>;
 		close(allowReconnect?: boolean): Promise<this>;
 		broadcast(data: any): Promise<void>;
-		survey(data: any, timeout?: number): Promise<PromiseSettled>;
-		ping(data?: any, timeout?: number): Promise<PromiseSettled>;
+		survey(data: any, timeout?: number): Promise<Array<PromiseSettled>>;
+		ping(data?: any, timeout?: number): Promise<Array<PromiseSettled>>;
 		pause(): void;
 		resume(): void;
 		connections: Connection[];


### PR DESCRIPTION
Not sure if you what you prefer

```ts
survey(data: any, timeout?: number): Promise<Array<PromiseSettled>>;
ping(data?: any, timeout?: number): Promise<Array<PromiseSettled>>;
```
> This is the version used in the docs
https://github.com/timotejroiko/net-ipc/blob/master/docs/server.md#surveydata-timeout

or 

```ts
survey(data: any, timeout?: number): Promise<PromiseSettled[]>;
ping(data?: any, timeout?: number): Promise<PromiseSettled[]>;
```

Best regards.
